### PR TITLE
Renamed fc type to protocol type and renamed FCs to the protocol they use

### DIFF
--- a/inc/Board.h
+++ b/inc/Board.h
@@ -70,11 +70,13 @@ enum thread_prio_e
 	THREAD_PRIO_HIGHEST = 4, /* @note: this has to match (configMAX_PRIORITIES - 1) */
 };
 
-//all supports flight control type
-enum FC_Type_e
+//all supported protocols
+enum FC_Protocol
 {
-	FC_APM_PIXHAWK = 0,
-	FC_CC3D_REVO = 1,
+	PROTOCOL_MAVLINK = 0,
+	PROTOCOL_UAVTALK = 1,
+	PROTOCOL_MWII = 2,
+	PROTOCOL_GPS = 3,
 	//FC_DJI_NAZAV2 = 3,
 };
 

--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -221,7 +221,7 @@ typedef union{
 		uint16_t RSSI_max;
 		uint16_t RSSI_raw_en;
 		
-		uint16_t FC_Type;	
+		uint16_t FC_Protocol;
 		
 //		//below is unused. if add a param, reduce one item here
 //		uint16_t unused[EERROM_SIZE/2 - 104];

--- a/src/Board.c
+++ b/src/Board.c
@@ -144,7 +144,7 @@ void module_init(void)
 	//suspend the VCP routine when start. Resume it when the use connecting
 	//vTaskSuspend(xTaskVCPHandle);
 
-	switch(eeprom_buffer.params.FC_Type){
+	switch(eeprom_buffer.params.FC_Protocol){
 		case PROTOCOL_MAVLINK:
 			xTaskCreate( MavlinkTask, (const char*)"Task Mavlink",
 						 STACK_SIZE_MIN*2, NULL, THREAD_PRIO_HIGH, NULL );

--- a/src/Board.c
+++ b/src/Board.c
@@ -145,11 +145,11 @@ void module_init(void)
 	//vTaskSuspend(xTaskVCPHandle);
 
 	switch(eeprom_buffer.params.FC_Type){
-		case FC_APM_PIXHAWK:
+		case PROTOCOL_MAVLINK:
 			xTaskCreate( MavlinkTask, (const char*)"Task Mavlink",
 						 STACK_SIZE_MIN*2, NULL, THREAD_PRIO_HIGH, NULL );
 			break;
-		case FC_CC3D_REVO:
+		case PROTOCOL_UAVTALK:
 			xTaskCreate( UAVTalkTask, (const char*)"Task UAVTalk",
 						 STACK_SIZE_MIN*2, NULL, THREAD_PRIO_HIGH, NULL );
 			break;

--- a/src/usart2.c
+++ b/src/usart2.c
@@ -95,7 +95,7 @@ void mavlink_usart_init(uint32_t baudRate)
 	USART_ITConfig(USART3, USART_IT_RXNE, ENABLE);
     USART_Cmd(USART3, ENABLE);
 	
-	switch(eeprom_buffer.params.FC_Type){
+	switch(eeprom_buffer.params.FC_Protocol){
 		case PROTOCOL_MAVLINK:
 			//start with "0xFE"
 			protocol_start = 0xFE;
@@ -127,7 +127,7 @@ void USART3_IRQHandler(void)
 			mavlink_buf_swap();
 			mavlink_recv_pos = 0;
 			memset(mavlink_buffer_recv, 0, MAVLINK_BUFFER_SIZE);
-			switch(eeprom_buffer.params.FC_Type){
+			switch(eeprom_buffer.params.FC_Protocol){
 				case PROTOCOL_MAVLINK:
 					xSemaphoreGiveFromISR(onMavlinkSemaphore, &xHigherPriorityTaskWoken);
 					break;

--- a/src/usart2.c
+++ b/src/usart2.c
@@ -96,11 +96,11 @@ void mavlink_usart_init(uint32_t baudRate)
     USART_Cmd(USART3, ENABLE);
 	
 	switch(eeprom_buffer.params.FC_Type){
-		case FC_APM_PIXHAWK:
+		case PROTOCOL_MAVLINK:
 			//start with "0xFE"
 			protocol_start = 0xFE;
 			break;
-		case FC_CC3D_REVO:
+		case PROTOCOL_UAVTALK:
 			//start with "0x3C"
 			protocol_start = 0x3C;
 			break;
@@ -128,10 +128,10 @@ void USART3_IRQHandler(void)
 			mavlink_recv_pos = 0;
 			memset(mavlink_buffer_recv, 0, MAVLINK_BUFFER_SIZE);
 			switch(eeprom_buffer.params.FC_Type){
-				case FC_APM_PIXHAWK:
+				case PROTOCOL_MAVLINK:
 					xSemaphoreGiveFromISR(onMavlinkSemaphore, &xHigherPriorityTaskWoken);
 					break;
-				case FC_CC3D_REVO:
+				case PROTOCOL_UAVTALK:
 					xSemaphoreGiveFromISR(onUAVTalkSemaphore, &xHigherPriorityTaskWoken);
 					break;
 				default:


### PR DESCRIPTION
The OSD should be able to support different protocols instead of different FCs. For example CC3D can be used with openpilot and cleanflight/baseflight. That makes it possible to use MWII or UAVTalk protocol on CC3D depending on used firmware.

I renamed the protocols to PROTOCOL_MAVLINK (pixawk, apm) PROTOCOL_UAVTALK (open pilot), PROTOCOL_MWII (cleanflight, baseflight, multiwii), PROTOCOL_GPS (direct gps parsing). More are likely to follow.
