### PR TITLE
Added current consumed from mavlink protocol

### DIFF
--- a/inc/osdconfig.h
+++ b/inc/osdconfig.h
@@ -45,6 +45,7 @@ typedef union{
 		uint16_t BattConsumed_posY;
 		uint16_t BattConsumed_fontsize;
 		uint16_t BattConsumed_align;		
+		uint16_t BattConsumed_InMah;
 		
 		uint16_t FlightMode_en;
 		uint16_t FlightMode_panel;

--- a/inc/osdvar.h
+++ b/inc/osdvar.h
@@ -20,6 +20,7 @@ extern u32      armed_start_time;
 extern float        osd_vbat_A;                 // Battery A voltage in milivolt
 extern int16_t      osd_curr_A;                 // Battery A current
 extern int8_t       osd_battery_remaining_A;    // 0 to 100 <=> 0 to 1000
+extern int32_t 		osd_battery_consumed_in_mah;// Consumed current in mAh
 
 extern float       osd_pitch;                  // pitch from DCM
 extern float       osd_roll;                   // roll from DCM

--- a/src/osdmavlink.c
+++ b/src/osdmavlink.c
@@ -165,6 +165,11 @@ void parseMavlink(void)
                         osd_windSpeed = mavlink_msg_wind_get_speed(&msg); //m/s
                     }
                     break;
+                case MAVLINK_MSG_ID_BATTERY_STATUS:
+                	{
+                		osd_battery_consumed_in_mah = mavlink_msg_battery_status_get_current_consumed(&msg);
+                	}
+                break;
                 default:
                     //Do nothing
                     break;

--- a/src/osdproc.c
+++ b/src/osdproc.c
@@ -144,10 +144,17 @@ void RenderScreen(void)
     }
     if(eeprom_buffer.params.BattConsumed_en && bShownAtPanle(eeprom_buffer.params.BattConsumed_panel))
     {
-        sprintf(tmp_str, "%d/", osd_battery_remaining_A);
-        write_string(tmp_str, eeprom_buffer.params.BattConsumed_posX, eeprom_buffer.params.BattConsumed_posY,
-                     0, 0, TEXT_VA_TOP, eeprom_buffer.params.BattConsumed_align, 0,
-                     SIZE_TO_FONT[eeprom_buffer.params.BattConsumed_fontsize]);
+    	if (eeprom_buffer.params.BattConsumed_InMah){
+    		sprintf(tmp_str, "%dmAh", osd_battery_consumed_in_mah);
+    		    		        write_string(tmp_str, eeprom_buffer.params.BattConsumed_posX, eeprom_buffer.params.BattConsumed_posY,
+    		    		                     0, 0, TEXT_VA_TOP, eeprom_buffer.params.BattConsumed_align, 0,
+    		    		                     SIZE_TO_FONT[eeprom_buffer.params.BattConsumed_fontsize]);
+    	}else{
+    		sprintf(tmp_str, "%d/", osd_battery_remaining_A);
+    		        write_string(tmp_str, eeprom_buffer.params.BattConsumed_posX, eeprom_buffer.params.BattConsumed_posY,
+    		                     0, 0, TEXT_VA_TOP, eeprom_buffer.params.BattConsumed_align, 0,
+    		                     SIZE_TO_FONT[eeprom_buffer.params.BattConsumed_fontsize]);
+    	}
     }
 
 

--- a/src/osdvar.c
+++ b/src/osdvar.c
@@ -32,6 +32,7 @@ u32 armed_start_time = 0;
 float osd_vbat_A = 0.0f;                 // Battery A voltage in milivolt
 int16_t osd_curr_A = 0;                 // Battery A current
 int8_t osd_battery_remaining_A = 0;    // 0 to 100 <=> 0 to 1000
+int32_t osd_battery_consumed_in_mah = 0;
 
 float osd_pitch = 0.0f;                  // pitch from DCM
 float osd_roll = 0.0f;                   // roll from DCM


### PR DESCRIPTION
I added the message that reads the consumed current so it can be displayed instead of the % value. This was requested here:
http://fpv-community.de/showthread.php?66113-PlayUavOSD-Full-Graphics-OSD-auf-STM32-basis&p=849878&viewfull=1#post849878

Link to message definition:
https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml#L2767

In Config tool we need to set BattConsumed_InMah to 1 for mAh or 0 for %. This setting needs to be added to cofig tool.

Its untested as i do not have a APM/Pixhawk with me. Can you please test it? osd_battery_consumed_in_mah will be -1 if AP does not support current consumed reading.

Also i'm not sure with this part:
sprintf(tmp_str, "%d/", osd_battery_remaining_A); -> sprintf(tmp_str, "%dmAh", osd_battery_consumed_in_mah);

There is no '%' char, do you add that somewhere else in the code? If yes that needs to be disabled in case of consumed mAh.
