### PR TITLE
Update osdproc.c

### DIFF
--- a/src/osdproc.c
+++ b/src/osdproc.c
@@ -561,11 +561,14 @@ void RenderScreen(void)
         if ((eeprom_buffer.params.RSSI_raw_en == 0)) {
             uint16_t rssiMin = eeprom_buffer.params.RSSI_min;
             uint16_t rssiMax = eeprom_buffer.params.RSSI_max;
-
-            if (rssiMin < 0)
-                rssiMin = 0;
-            if (rssiMax > 255)
-                rssiMax = 255;
+            
+            //Trim the rssiMAX/MIN only for MAVLINK-rssi
+            if(eeprom_buffer.params.RSSI_type == 0){
+                if (rssiMin < 0)
+                    rssiMin = 0;
+                if (rssiMax > 255)
+                    rssiMax = 255;
+            }
 
             if ((rssiMax - rssiMin) > 0)
                 rssi = (int) ((float) (rssi - rssiMin) / (float) (rssiMax - rssiMin) * 100.0f);


### PR DESCRIPTION
uncommented rssiMAX / MIN limitations to make percentage scaling for pwm rssi over rc channel work
